### PR TITLE
initial multi-gateway support

### DIFF
--- a/ceph-nvmeof.conf
+++ b/ceph-nvmeof.conf
@@ -14,6 +14,8 @@ group =
 addr = 127.0.0.1
 port = 5500
 enable_auth = False
+state_update_notify = True
+state_update_interval_sec = 5
 
 [ceph]
 

--- a/control/__main__.py
+++ b/control/__main__.py
@@ -32,3 +32,4 @@ if __name__ == '__main__':
     config = GatewayConfig(args.config)
     with GatewayServer(config) as gateway:
         gateway.serve()
+        gateway.keep_alive()

--- a/control/cli.py
+++ b/control/cli.py
@@ -194,13 +194,15 @@ class GatewayClient:
     @cli.cmd([
         argument("-n", "--subnqn", help="Subsystem NQN", required=True),
         argument("-b", "--bdev", help="Bdev name", required=True),
+        argument("-i", "--nsid", help="Namespace ID", type=int),
     ])
     def add_namespace(self, args):
         """Adds a namespace to a subsystem."""
 
         try:
             req = pb2.add_namespace_req(subsystem_nqn=args.subnqn,
-                                        bdev_name=args.bdev)
+                                        bdev_name=args.bdev,
+                                        nsid=args.nsid)
             ret = self.stub.add_namespace(req)
             self.logger.info(
                 f"Added namespace {ret.nsid} to {args.subnqn}: {ret.status}")

--- a/control/grpc.py
+++ b/control/grpc.py
@@ -47,10 +47,9 @@ class GatewayService(pb2_grpc.GatewayServicer):
         """Creates a bdev from an RBD image."""
 
         name = str(uuid.uuid4()) if not request.bdev_name else request.bdev_name
-        self.logger.info(
-            f"Received request to create bdev {name} from"
-            f" {request.rbd_pool_name}/{request.rbd_image_name}"
-            f" with block size {request.block_size}")
+        self.logger.info(f"Received request to create bdev {name} from"
+                         f" {request.rbd_pool_name}/{request.rbd_image_name}"
+                         f" with block size {request.block_size}")
         try:
             bdev_name = self.spdk_rpc.bdev.bdev_rbd_create(
                 self.spdk_rpc_client,
@@ -83,8 +82,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
     def delete_bdev(self, request, context=None):
         """Deletes a bdev."""
 
-        self.logger.info(
-            f"Received request to delete bdev {request.bdev_name}")
+        self.logger.info(f"Received request to delete bdev {request.bdev_name}")
         try:
             ret = self.spdk_rpc.bdev.bdev_rbd_delete(
                 self.spdk_rpc_client,
@@ -146,7 +144,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
         """Deletes a subsystem."""
 
         self.logger.info(
-            f"Received request to delete {request.subsystem_nqn}")
+            f"Received request to delete subsystem {request.subsystem_nqn}")
         try:
             ret = self.spdk_rpc.nvmf.nvmf_delete_subsystem(
                 self.spdk_rpc_client,
@@ -194,6 +192,8 @@ class GatewayService(pb2_grpc.GatewayServicer):
         if context:
             # Update gateway state
             try:
+                if not request.nsid:
+                    request.nsid = nsid
                 json_req = json_format.MessageToJson(
                     request, preserving_proto_field_name=True)
                 self.gateway_state.add_namespace(request.subsystem_nqn,
@@ -272,8 +272,7 @@ class GatewayService(pb2_grpc.GatewayServicer):
                 json_req = json_format.MessageToJson(
                     request, preserving_proto_field_name=True)
                 self.gateway_state.add_host(request.subsystem_nqn,
-                                            request.host_nqn,
-                                            json_req)
+                                            request.host_nqn, json_req)
             except Exception as ex:
                 self.logger.error(
                     f"Error persisting add_host {request.host_nqn}: {ex}")
@@ -326,10 +325,10 @@ class GatewayService(pb2_grpc.GatewayServicer):
     def create_listener(self, request, context=None):
         """Creates a listener for a subsystem at a given IP/Port."""
 
-        self.logger.info(
-            f"Received request to create {request.gateway_name}"
-            f" {request.trtype} listener for {request.nqn} at"
-            f" {request.traddr}:{request.trsvcid}.")
+        ret = True
+        self.logger.info(f"Received request to create {request.gateway_name}"
+                         f" {request.trtype} listener for {request.nqn} at"
+                         f" {request.traddr}:{request.trsvcid}.")
         try:
             if (request.gateway_name and not request.traddr) or \
                (not request.gateway_name and request.traddr):
@@ -368,10 +367,8 @@ class GatewayService(pb2_grpc.GatewayServicer):
                     request, preserving_proto_field_name=True)
                 self.gateway_state.add_listener(request.nqn,
                                                 request.gateway_name,
-                                                request.trtype,
-                                                request.traddr,
-                                                request.trsvcid,
-                                                json_req)
+                                                request.trtype, request.traddr,
+                                                request.trsvcid, json_req)
             except Exception as ex:
                 self.logger.error(
                     f"Error persisting add_listener {request.trsvcid}: {ex}")
@@ -382,10 +379,10 @@ class GatewayService(pb2_grpc.GatewayServicer):
     def delete_listener(self, request, context=None):
         """Deletes a listener from a subsystem at a given IP/Port."""
 
-        self.logger.info(
-            f"Received request to delete {request.gateway_name}"
-            f" {request.trtype} listener for {request.nqn} at"
-            f" {request.traddr}:{request.trsvcid}.")
+        ret = True
+        self.logger.info(f"Received request to delete {request.gateway_name}"
+                         f" {request.trtype} listener for {request.nqn} at"
+                         f" {request.traddr}:{request.trsvcid}.")
         try:
             if (request.gateway_name and not request.traddr) or \
                (not request.gateway_name and request.traddr):

--- a/control/server.py
+++ b/control/server.py
@@ -19,8 +19,10 @@ import grpc
 import json
 import logging
 from concurrent import futures
+from google.protobuf import json_format
+from .generated import gateway_pb2 as pb2
 from .generated import gateway_pb2_grpc as pb2_grpc
-from .state import OmapGatewayState
+from .state import GatewayState, LocalGatewayState, OmapGatewayState, GatewayStateHandler
 from .grpc import GatewayService
 
 libc = ctypes.CDLL(ctypes.util.find_library("c"))
@@ -41,8 +43,7 @@ class GatewayServer:
     Instance attributes:
         config: Basic gateway parameters
         logger: Logger instance to track server events
-        gateway_state: Methods for target state persistence
-        gateway_rpc: GatewayService object on which to make RPC calls directly
+        gateway_rpc: GatewayService implementation
         server: gRPC server instance to receive gateway client requests
         spdk_rpc: Module methods for SPDK
         spdk_rpc_client: Client of SPDK RPC server
@@ -54,17 +55,13 @@ class GatewayServer:
         self.logger = logging.getLogger(__name__)
         self.config = config
         self.spdk_process = None
+        self.gateway_rpc = None
         self.server = None
 
         gateway_name = self.config.get("gateway", "name")
         if not gateway_name:
             gateway_name = socket.gethostname()
         self.logger.info(f"Starting gateway {gateway_name}")
-
-        self._start_spdk()
-        self.gateway_state = OmapGatewayState(self.config)
-        self.gateway_rpc = GatewayService(self.config, self.gateway_state,
-                                          self.spdk_rpc, self.spdk_rpc_client)
 
     def __enter__(self):
         return self
@@ -91,14 +88,34 @@ class GatewayServer:
     def serve(self):
         """Starts gateway server."""
 
+        # Start SPDK
+        self._start_spdk()
+
         # Register service implementation with server
+        omap_state = OmapGatewayState(self.config)
+        local_state = LocalGatewayState()
+        gateway_state = GatewayStateHandler(self.config, local_state,
+                                            omap_state, self.gateway_rpc_caller)
+        self.gateway_rpc = GatewayService(self.config, gateway_state,
+                                          self.spdk_rpc, self.spdk_rpc_client)
         self.server = grpc.server(futures.ThreadPoolExecutor(max_workers=1))
         pb2_grpc.add_GatewayServicer_to_server(self.gateway_rpc, self.server)
+
+        # Add listener port
+        self._add_server_listener()
+
+        # Check for existing NVMeoF target state
+        gateway_state.start_update()
+
+        # Start server
+        self.server.start()
+
+    def _add_server_listener(self):
+        """Adds listener port to server."""
 
         enable_auth = self.config.getboolean("gateway", "enable_auth")
         gateway_addr = self.config.get("gateway", "addr")
         gateway_port = self.config.get("gateway", "port")
-
         if enable_auth:
             # Read in key and certificates for authentication
             server_key = self.config.get("mtls", "server_key")
@@ -126,19 +143,6 @@ class GatewayServer:
             self.server.add_insecure_port("{}:{}".format(
                 gateway_addr, gateway_port))
 
-        # Check for existing NVMeoF target state
-        self._restore_state()
-        # Start server
-        self.logger.info("Starting server...")
-        self.server.start()
-        while True:
-            timedout = self.server.wait_for_termination(timeout=1)
-            if not timedout:
-                break
-            alive = self._ping()
-            if not alive:
-                break
-
     def _start_spdk(self):
         """Starts SPDK process."""
 
@@ -152,8 +156,7 @@ class GatewayServer:
         # Start target
         tgt_path = self.config.get("spdk", "tgt_path")
         spdk_rpc_socket = self.config.get("spdk", "rpc_socket")
-        spdk_tgt_cmd_extra_args = self.config.get("spdk",
-                                                  "tgt_cmd_extra_args")
+        spdk_tgt_cmd_extra_args = self.config.get("spdk", "tgt_cmd_extra_args")
         spdk_cmd = os.path.join(spdk_path, tgt_path)
         cmd = [spdk_cmd, "-u", "-r", spdk_rpc_socket]
         if spdk_tgt_cmd_extra_args:
@@ -195,8 +198,8 @@ class GatewayServer:
             raise
 
         # Implicitly create transports
-        spdk_transports = self.config.get_with_default(
-            "spdk", "transports", "tcp")
+        spdk_transports = self.config.get_with_default("spdk", "transports",
+                                                       "tcp")
         for trtype in spdk_transports.split():
             self._create_transport(trtype.lower())
 
@@ -224,16 +227,15 @@ class GatewayServer:
                 f"Create Transport {trtype} returned with error: \n {ex}")
             raise
 
-    def _restore_state(self):
-        """Restores NVMeoF target state."""
-        callbacks = {
-            self.gateway_state.BDEV_PREFIX: self.gateway_rpc.create_bdev,
-            self.gateway_state.SUBSYSTEM_PREFIX: self.gateway_rpc.create_subsystem,
-            self.gateway_state.NAMESPACE_PREFIX: self.gateway_rpc.add_namespace,
-            self.gateway_state.HOST_PREFIX: self.gateway_rpc.add_host,
-            self.gateway_state.LISTENER_PREFIX: self.gateway_rpc.create_listener
-        }
-        self.gateway_state.restore(callbacks)
+    def keep_alive(self):
+        """Continuously confirms communication with SPDK process."""
+        while True:
+            timedout = self.server.wait_for_termination(timeout=1)
+            if not timedout:
+                break
+            alive = self._ping()
+            if not alive:
+                break
 
     def _ping(self):
         """Confirms communication with SPDK process."""
@@ -243,3 +245,48 @@ class GatewayServer:
         except Exception as ex:
             self.logger.error(f"spdk_get_version failed with: \n {ex}")
             return False
+
+    def gateway_rpc_caller(self, requests, is_add_req):
+        """Passes RPC requests to gateway service."""
+        for key, val in requests.items():
+            if key.startswith(GatewayState.BDEV_PREFIX):
+                if is_add_req:
+                    req = json_format.Parse(val, pb2.create_bdev_req())
+                    self.gateway_rpc.create_bdev(req)
+                else:
+                    req = json_format.Parse(val,
+                                            pb2.delete_bdev_req(),
+                                            ignore_unknown_fields=True)
+                    self.gateway_rpc.delete_bdev(req)
+            elif key.startswith(GatewayState.SUBSYSTEM_PREFIX):
+                if is_add_req:
+                    req = json_format.Parse(val, pb2.create_subsystem_req())
+                    self.gateway_rpc.create_subsystem(req)
+                else:
+                    req = json_format.Parse(val,
+                                            pb2.delete_subsystem_req(),
+                                            ignore_unknown_fields=True)
+                    self.gateway_rpc.delete_subsystem(req)
+            elif key.startswith(GatewayState.NAMESPACE_PREFIX):
+                if is_add_req:
+                    req = json_format.Parse(val, pb2.add_namespace_req())
+                    self.gateway_rpc.add_namespace(req)
+                else:
+                    req = json_format.Parse(val,
+                                            pb2.remove_namespace_req(),
+                                            ignore_unknown_fields=True)
+                    self.gateway_rpc.remove_namespace(req)
+            elif key.startswith(GatewayState.HOST_PREFIX):
+                if is_add_req:
+                    req = json_format.Parse(val, pb2.add_host_req())
+                    self.gateway_rpc.add_host(req)
+                else:
+                    req = json_format.Parse(val, pb2.remove_host_req())
+                    self.gateway_rpc.remove_host(req)
+            elif key.startswith(GatewayState.LISTENER_PREFIX):
+                if is_add_req:
+                    req = json_format.Parse(val, pb2.create_listener_req())
+                    self.gateway_rpc.create_listener(req)
+                else:
+                    req = json_format.Parse(val, pb2.delete_listener_req())
+                    self.gateway_rpc.delete_listener(req)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,35 @@
+import pytest
+import rados
+from control.config import GatewayConfig
+from control.state import OmapGatewayState
+
+
+def pytest_addoption(parser):
+    """Sets command line options for testing."""
+    # Specify base config file for tests
+    parser.addoption("--config",
+                     action="store",
+                     help="Path to config file",
+                     default="ceph-nvmeof.conf")
+    parser.addoption("--image",
+                     action="store",
+                     help="RBD image name",
+                     default="mytestdevimage")
+
+
+@pytest.fixture(scope="session")
+def conffile(request):
+    """Returns the command line input for the config file."""
+    return request.config.getoption("--config")
+
+
+@pytest.fixture(scope="session")
+def config(conffile):
+    """Returns config file settings."""
+    return GatewayConfig(conffile)
+
+
+@pytest.fixture(scope="session")
+def image(request):
+    """Returns the command line input for the test rbd image name."""
+    return request.config.getoption("--image")

--- a/tests/test_multi_gateway.py
+++ b/tests/test_multi_gateway.py
@@ -1,0 +1,106 @@
+import pytest
+import copy
+import grpc
+import json
+import time
+from control.server import GatewayServer
+from control.generated import gateway_pb2 as pb2
+from control.generated import gateway_pb2_grpc as pb2_grpc
+
+update_notify = True
+update_interval_sec = 5
+
+
+@pytest.fixture(scope="module")
+def conn(config):
+    """Sets up and tears down Gateways A and B."""
+    # Setup GatewayA and GatewayB configs
+    configA = copy.deepcopy(config)
+    configA.config["gateway"]["name"] = "GatewayA"
+    configA.config["gateway"]["group"] = "Group1"
+    configA.config["gateway"]["state_update_notify"] = str(update_notify)
+    configB = copy.deepcopy(configA)
+    addr = configA.get("gateway", "addr")
+    portA = configA.getint("gateway", "port")
+    portB = portA + 1
+    configB.config["gateway"]["name"] = "GatewayB"
+    configB.config["gateway"]["port"] = str(portB)
+    configB.config["gateway"]["state_update_interval_sec"] = str(
+        update_interval_sec)
+    configB.config["spdk"]["rpc_socket"] = "/var/tmp/spdk_GatewayB.sock"
+
+    # Start servers
+    gatewayA = GatewayServer(configA)
+    gatewayA.serve()
+    # Delete existing OMAP state
+    gatewayA.gateway_rpc.gateway_state.delete_state()
+    # Create new
+    gatewayB = GatewayServer(configB)
+    gatewayB.serve()
+
+    # Bind the client and Gateways A & B
+    channelA = grpc.insecure_channel(f"{addr}:{portA}")
+    stubA = pb2_grpc.GatewayStub(channelA)
+    channelB = grpc.insecure_channel(f"{addr}:{portB}")
+    stubB = pb2_grpc.GatewayStub(channelB)
+    yield stubA, stubB
+
+    # Stop gateways
+    gatewayA.server.stop(grace=1)
+    gatewayB.server.stop(grace=1)
+    gatewayB.gateway_rpc.gateway_state.delete_state()
+
+
+def test_multi_gateway_coordination(config, image, conn):
+    """Tests state coordination in a gateway group.
+    
+    Sends requests to GatewayA to set up a subsystem with a single namespace
+    and checks if GatewayB has the the identical state after watch/notify and/or
+    periodic polling.
+    """
+    stubA, stubB = conn
+
+    bdev = "Ceph0"
+    nqn = "nqn.2016-06.io.spdk:cnode1"
+    serial = "SPDK00000000000001"
+    nsid = 10
+    pool = config.get("ceph", "pool")
+
+    # Send requests to create a subsytem with one namespace to GatewayA
+    bdev_req = pb2.create_bdev_req(bdev_name=bdev,
+                                   rbd_pool_name=pool,
+                                   rbd_image_name=image,
+                                   block_size=4096)
+    subsystem_req = pb2.create_subsystem_req(subsystem_nqn=nqn,
+                                             serial_number=serial)
+    namespace_req = pb2.add_namespace_req(subsystem_nqn=nqn,
+                                          bdev_name=bdev,
+                                          nsid=nsid)
+    get_subsystems_req = pb2.get_subsystems_req()
+    ret_bdev = stubA.create_bdev(bdev_req)
+    ret_subsystem = stubA.create_subsystem(subsystem_req)
+    ret_namespace = stubA.add_namespace(namespace_req)
+    assert ret_bdev.status is True
+    assert ret_subsystem.status is True
+    assert ret_namespace.status is True
+
+    # Watch/Notify
+    if update_notify:
+        time.sleep(1)
+        watchB = stubB.get_subsystems(get_subsystems_req)
+        listB = json.loads(watchB.subsystems)
+        assert len(listB) == 2
+        assert listB[1]["nqn"] == nqn
+        assert listB[1]["serial_number"] == serial
+        assert listB[1]["namespaces"][0]["nsid"] == nsid
+        assert listB[1]["namespaces"][0]["bdev_name"] == bdev
+
+    # Periodic update
+    time.sleep(update_interval_sec + 1)
+    pollB = stubB.get_subsystems(get_subsystems_req)
+    listB = json.loads(pollB.subsystems)
+    assert len(listB) == 2
+    assert listB[1]["nqn"] == nqn
+    assert listB[1]["serial_number"] == serial
+    assert listB[1]["namespaces"][0]["nsid"] == nsid
+    assert listB[1]["namespaces"][0]["bdev_name"] == bdev

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,171 @@
+import pytest
+import time
+import rados
+from control.state import LocalGatewayState, OmapGatewayState, GatewayStateHandler
+
+
+@pytest.fixture(scope="module")
+def ioctx(config):
+    """Opens IO context to ceph pool."""
+    ceph_pool = config.get("ceph", "pool")
+    ceph_conf = config.get("ceph", "config_file")
+    conn = rados.Rados(conffile=ceph_conf)
+    conn.connect()
+    ioctx = conn.open_ioctx(ceph_pool)
+    yield ioctx
+    ioctx.close()
+
+
+@pytest.fixture
+def local_state():
+    """Returns local state object."""
+    return LocalGatewayState()
+
+
+@pytest.fixture
+def omap_state(config):
+    """Sets up and tears down OMAP state object."""
+    omap = OmapGatewayState(config)
+    omap.delete_state()
+    yield omap
+    omap.delete_state()
+
+
+def add_key(ioctx, key, value, version, omap_name, omap_version_key):
+    """Adds key to the specified OMAP and sets version number."""
+    with rados.WriteOpCtx() as write_op:
+        ioctx.set_omap(write_op, (key,), (value,))
+        ioctx.set_omap(write_op, (omap_version_key,), (str(version),))
+        ioctx.operate_write_op(write_op, omap_name)
+
+
+def remove_key(ioctx, key, version, omap_name, omap_version_key):
+    """Removes key from the specified OMAP."""
+    with rados.WriteOpCtx() as write_op:
+        ioctx.remove_omap_keys(write_op, (key,))
+        ioctx.set_omap(write_op, (omap_version_key,), (str(version),))
+        ioctx.operate_write_op(write_op, omap_name)
+
+
+def test_state_polling_update(config, ioctx, local_state, omap_state):
+    """Confirms periodic polling of the OMAP for updates."""
+
+    update_counter = 0
+
+    def _state_polling_update(update, is_add_req):
+        nonlocal update_counter
+        update_counter += 1
+        for k, v in update.items():
+            # Check for addition
+            if update_counter == 1:
+                assert is_add_req is True
+                assert k == key
+                assert v.decode("utf-8") == "add"
+            # Check for two-step change
+            if update_counter == 2:
+                assert is_add_req is False
+                assert k == key
+                assert v.decode("utf-8") == "changed"
+            if update_counter == 3:
+                assert is_add_req is True
+                assert k == key
+                assert v.decode("utf-8") == "changed"
+            # Check for removal
+            if update_counter == 4:
+                assert is_add_req is False
+                assert k == key
+            assert update_counter < 5
+
+    version = 1
+    update_interval_sec = 1
+    state = GatewayStateHandler(config, local_state, omap_state,
+                                _state_polling_update)
+    state.update_interval = update_interval_sec
+    state.use_notify = False
+    key = "bdev_test"
+    state.start_update()
+
+    # Add bdev key to OMAP and update version number
+    version += 1
+    add_key(ioctx, key, "add", version, omap_state.omap_name,
+            omap_state.OMAP_VERSION_KEY)
+    time.sleep(update_interval_sec + 1)  # Allow time for polling
+
+    # Change bdev key and update version number
+    version += 1
+    add_key(ioctx, key, "changed", version, omap_state.omap_name,
+            omap_state.OMAP_VERSION_KEY)
+    time.sleep(update_interval_sec + 1)  # Allow time for polling
+
+    # Remove bdev key and update version number
+    version += 1
+    remove_key(ioctx, key, version, omap_state.omap_name,
+               omap_state.OMAP_VERSION_KEY)
+    time.sleep(update_interval_sec + 1)  # Allow time for polling
+
+    assert update_counter == 4
+
+
+def test_state_notify_update(config, ioctx, local_state, omap_state):
+    """Confirms use of OMAP watch/notify for updates."""
+
+    update_counter = 0
+
+    def _state_notify_update(update, is_add_req):
+        nonlocal update_counter
+        update_counter += 1
+        elapsed = time.time() - start
+        assert elapsed < update_interval_sec
+        for k, v in update.items():
+            # Check for addition
+            if update_counter == 1:
+                assert is_add_req is True
+                assert k == key
+                assert v.decode("utf-8") == "add"
+            # Check for two-step change
+            if update_counter == 2:
+                assert is_add_req is False
+                assert k == key
+                assert v.decode("utf-8") == "changed"
+            if update_counter == 3:
+                assert is_add_req is True
+                assert k == key
+                assert v.decode("utf-8") == "changed"
+            # Check for removal
+            if update_counter == 4:
+                assert is_add_req is False
+                assert k == key
+            assert update_counter < 5
+
+    version = 1
+    update_interval_sec = 10
+    state = GatewayStateHandler(config, local_state, omap_state,
+                                _state_notify_update)
+    key = "bdev_test"
+    state.update_interval = update_interval_sec
+    state.use_notify = True
+    start = time.time()
+    state.start_update()
+
+    # Add bdev key to OMAP and update version number
+    version += 1
+    add_key(ioctx, key, "add", version, omap_state.omap_name,
+            omap_state.OMAP_VERSION_KEY)
+    assert (ioctx.notify(omap_state.omap_name))  # Send notify signal
+
+    # Change bdev key and update version number
+    version += 1
+    add_key(ioctx, key, "changed", version, omap_state.omap_name,
+            omap_state.OMAP_VERSION_KEY)
+    assert (ioctx.notify(omap_state.omap_name))  # Send notify signal
+
+    # Remove bdev key and update version number
+    version += 1
+    remove_key(ioctx, key, version, omap_state.omap_name,
+               omap_state.OMAP_VERSION_KEY)
+    assert (ioctx.notify(omap_state.omap_name))  # Send notify signal
+
+    time.sleep(0.5)
+    elapsed = time.time() - start
+    assert update_counter == 4
+    assert elapsed < update_interval_sec


### PR DESCRIPTION
This commit allows for coordination of the target state within all gateways in a gateway group. This functionality is only supported when all requests are sent to a single gateway. Sending requests to mutliple gateways within the group may result in error if a gateway receives a new request while in an outdated state. With the state_update_notify config option, gateways register a watch on the group's OMAP object and send notify signals to the object after state changes. Gateways check for OMAP updates upon receiving the watch callback as well as periodically according to an state_update_interval_sec config parameter.